### PR TITLE
Use the OpStream's OffSetToSource directly

### DIFF
--- a/cmd/tealdbg/debugger.go
+++ b/cmd/tealdbg/debugger.go
@@ -364,7 +364,7 @@ func (s *session) GetSourceMap() ([]byte, error) {
 	lines := make([]string, len(s.lines))
 	const targetCol int = 0
 	const sourceIdx int = 0
-	prevSourceLine := 0
+	prevLoc := logic.SourceLocation{Line: 0, Column: 0}
 
 	// the very first entry is needed by CDT
 	lines[0] = logic.MakeSourceMapLine(targetCol, sourceIdx, 0, 0)
@@ -374,16 +374,17 @@ func (s *session) GetSourceMap() ([]byte, error) {
 			if !ok {
 				lines[targetLine] = ""
 			} else {
-				lines[targetLine] = logic.MakeSourceMapLine(targetCol, sourceIdx, source.Line-prevSourceLine, source.Column)
-				prevSourceLine = source.Line
+				lines[targetLine] = logic.MakeSourceMapLine(targetCol, sourceIdx, source.Line-prevLoc.Line, source.Column-prevLoc.Column)
+				prevLoc = source
 			}
 		} else {
-			delta := 0
+			ldelta, cdelta := 0, 0
 			// the very last empty line, increment by number src number by 1
 			if targetLine == len(s.lines)-1 {
-				delta = 1
+				ldelta = 1
+				cdelta = -prevLoc.Column
 			}
-			lines[targetLine] = logic.MakeSourceMapLine(targetCol, sourceIdx, delta, 0)
+			lines[targetLine] = logic.MakeSourceMapLine(targetCol, sourceIdx, ldelta, cdelta)
 		}
 	}
 

--- a/cmd/tealdbg/debugger_test.go
+++ b/cmd/tealdbg/debugger_test.go
@@ -130,17 +130,15 @@ func createSessionFromSource(t *testing.T, program string) *session {
 
 	// create a sample disassembly line to pc mapping
 	// this simple source is similar to disassembly except intcblock at the beginning
-	offsetToLine := make(map[int]int, len(ops.OffsetToSource))
 	pcOffset := make(map[int]int, len(ops.OffsetToSource))
 	for pc, location := range ops.OffsetToSource {
-		offsetToLine[pc] = location.Line
 		pcOffset[location.Line+1] = pc
 	}
 
 	s := makeSession(disassembly, 0)
 	s.source = source
 	s.programName = "test"
-	s.offsetToLine = offsetToLine
+	s.offsetToSource = ops.OffsetToSource
 	s.pcOffset = pcOffset
 
 	return s

--- a/cmd/tealdbg/local.go
+++ b/cmd/tealdbg/local.go
@@ -225,16 +225,16 @@ const (
 
 // evaluation is a description of a single debugger run
 type evaluation struct {
-	program      []byte
-	source       string
-	offsetToLine map[int]int
-	name         string
-	groupIndex   uint64
-	mode         modeType
-	aidx         basics.AppIndex
-	ba           apply.Balances
-	result       evalResult
-	states       AppState
+	program        []byte
+	source         string
+	offsetToSource map[int]logic.SourceLocation
+	name           string
+	groupIndex     uint64
+	mode           modeType
+	aidx           basics.AppIndex
+	ba             apply.Balances
+	result         evalResult
+	states         AppState
 }
 
 func (e *evaluation) eval(gi int, sep *logic.EvalParams, aep *logic.EvalParams) (pass bool, err error) {
@@ -395,11 +395,7 @@ func (r *LocalRunner) Setup(dp *DebugParams) (err error) {
 				}
 				r.runs[i].program = ops.Program
 				if !dp.DisableSourceMap {
-					offsetToLine := make(map[int]int, len(ops.OffsetToSource))
-					for pc, location := range ops.OffsetToSource {
-						offsetToLine[pc] = location.Line
-					}
-					r.runs[i].offsetToLine = offsetToLine
+					r.runs[i].offsetToSource = ops.OffsetToSource
 					r.runs[i].source = source
 				}
 			}
@@ -551,7 +547,7 @@ func (r *LocalRunner) RunAll() error {
 	for i := range r.runs {
 		run := &r.runs[i]
 		if r.debugger != nil {
-			r.debugger.SaveProgram(run.name, run.program, run.source, run.offsetToLine, run.states)
+			r.debugger.SaveProgram(run.name, run.program, run.source, run.offsetToSource, run.states)
 		}
 
 		run.result.pass, run.result.err = run.eval(int(run.groupIndex), sep, aep)


### PR DESCRIPTION
Ok, I'll admit that GetSourceMap code was much weirder than I expected (like `const sourceCol int = 0`?)

Anyway, this seems like it can't be any different from what we had, except it gets the column right.